### PR TITLE
Migrate Swiftype from the WP plugin to the crawler

### DIFF
--- a/content.php
+++ b/content.php
@@ -18,7 +18,7 @@
 		</header><!-- .entry-header -->
 	</div>
     <div class="row">
-        <div class="entry-content small-24 columns">
+        <div data-swiftype-index='true' class="entry-content small-24 columns">
             <?php
                 /* translators: %s: Name of current post */
                 the_content( sprintf(

--- a/footer.php
+++ b/footer.php
@@ -53,7 +53,7 @@
       </div><!-- #content -->
  </div><!-- #page -->
 
-<footer id="colophon" class="site-footer" role="contentinfo">
+<footer data-swiftype-index='false' id="colophon" class="site-footer" role="contentinfo">
   <section class="fat">
     <div class="row">
       <div class="large-8 columns">

--- a/footer.php
+++ b/footer.php
@@ -115,7 +115,7 @@
   e=d.getElementsByTagName(t)[0];s.async=1;s.src=u;e.parentNode.insertBefore(s,e);
   })(window,document,'script','//s.swiftypecdn.com/install/v2/st.js','_st');
 
-  _st('install','3RAjBnyyCoAbUXNVZ3u2','2.0.0');
+  _st('install','<?php echo getenv("SWIFTYPE_ID") ?: "SET_SWIFTYPE_ID_ENV_VAR"; ?>','2.0.0');
 </script>
 <script>
   jQuery(document).foundation();

--- a/footer.php
+++ b/footer.php
@@ -109,6 +109,14 @@
 </footer><!-- #colophon -->
 
 <?php wp_footer(); ?>
+<script type="text/javascript">
+  (function(w,d,t,u,n,s,e){w['SwiftypeObject']=n;w[n]=w[n]||function(){
+  (w[n].q=w[n].q||[]).push(arguments);};s=d.createElement(t);
+  e=d.getElementsByTagName(t)[0];s.async=1;s.src=u;e.parentNode.insertBefore(s,e);
+  })(window,document,'script','//s.swiftypecdn.com/install/v2/st.js','_st');
+
+  _st('install','3RAjBnyyCoAbUXNVZ3u2','2.0.0');
+</script>
 <script>
   jQuery(document).foundation();
 </script>

--- a/header.php
+++ b/header.php
@@ -23,6 +23,9 @@
         <link rel="stylesheet" href="<?php echo get_stylesheet_directory_uri();?>/phila.gov-styles/ie9.css" type="text/css" media="all">
     <![endif]-->
 
+    <!-- Swiftype tags -->
+    <meta class="swiftype" name="title" data-type="string" content="<?php wp_title(''); ?>" />
+
     <?php wp_head(); ?>
 </head>
 

--- a/header.php
+++ b/header.php
@@ -25,6 +25,9 @@
 
     <!-- Swiftype tags -->
     <meta class="swiftype" name="title" data-type="string" content="<?php wp_title(''); ?>" />
+<?php if (is_single()) { ?>
+    <meta class="swiftype" name="published_at" data-type="date" content="<?php echo get_the_time('c', $post->ID); ?>" />
+<?php } ?>
 
     <?php wp_head(); ?>
 </head>

--- a/header.php
+++ b/header.php
@@ -46,7 +46,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 
 <div id="page" class="hfeed site">
     <?php if (alpha_alert()){ //show the alpha alert if set to true in functions.php ?>
-    <div class="alpha-alert">
+
+    <div data-swiftype-index='false' class="alpha-alert">
       <div class="row">
         <div class="large-18 columns">
                 <h1 class="h3">This service is in alpha</h1> <p>This is a work in progress. It may contain errors and inaccuracies. Help us improve it by providing feedback.</p>
@@ -62,7 +63,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </div>
       </div>
 <?php }  ?>
-    <header id="masthead" class="site-header" role="banner">
+    <header data-swiftype-index='false' id="masthead" class="site-header" role="banner">
         <div class="row">
             <div class="site-branding">
                 <div class="small-24 medium-12 columns">

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -47,6 +47,11 @@ function phila_gov_wp_title( $title, $sep ) {
 		return $title;
 	}
 
+	// Return the raw title if the separator is blank
+	if ( $sep == '') {
+		return $title;
+	}
+
 	global $page, $paged;
 
 	// Add the blog name

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -43,34 +43,39 @@ add_filter( 'body_class', 'phila_gov_body_classes' );
  * @return string The filtered title.
  */
 function phila_gov_wp_title( $title, $sep ) {
-	if ( is_feed() ) {
+	//force homepage to show something
+	if ($sep === '' && ( is_home() || is_front_page() )) {
+		$title .= get_bloginfo( 'name', 'display' );
+		return $title;
+
+	//just give us the page title
+	}elseif ( is_feed()  || $sep === '') {
+
+		return $title;
+
+	}else{
+
+		global $page, $paged;
+
+		// Add the blog name
+		$title .= get_bloginfo( 'name', 'display' );
+
+		// Add the blog description for the home/front page.
+		$site_description = get_bloginfo( 'description', 'display' );
+		if ( $site_description && ( is_home() || is_front_page() ) ) {
+			$title .= " $sep $site_description";
+		}
+
+		// Add a page number if necessary:
+		if ( ( $paged >= 2 || $page >= 2 ) && ! is_404() ) {
+			$title .= " $sep " . sprintf( __( 'Page %s', 'phila-gov' ), max( $paged, $page ) );
+		}
+
 		return $title;
 	}
-
-	// Return the raw title if the separator is blank
-	if ( $sep == '') {
-		return $title;
-	}
-
-	global $page, $paged;
-
-	// Add the blog name
-	$title .= get_bloginfo( 'name', 'display' );
-
-	// Add the blog description for the home/front page.
-	$site_description = get_bloginfo( 'description', 'display' );
-	if ( $site_description && ( is_home() || is_front_page() ) ) {
-		$title .= " $sep $site_description";
-	}
-
-	// Add a page number if necessary:
-	if ( ( $paged >= 2 || $page >= 2 ) && ! is_404() ) {
-		$title .= " $sep " . sprintf( __( 'Page %s', 'phila-gov' ), max( $paged, $page ) );
-	}
-
-	return $title;
 }
 add_filter( 'wp_title', 'phila_gov_wp_title', 10, 2 );
+
 
 /**
  * Sets the authordata global when viewing an author archive.

--- a/partials/content-modified.php
+++ b/partials/content-modified.php
@@ -9,6 +9,6 @@
 <div class="row">
   <div class="small-24 columns">
     <hr>
-    <p class="small-text">This content was last modified on: <?php the_modified_date(); ?></p>
+    <p class="small-text">This content was last modified on <time datetime="<?php the_modified_time('c'); ?>"><?php the_modified_date(); ?></time></p>
   </div>
 </div>

--- a/partials/content-news.php
+++ b/partials/content-news.php
@@ -42,6 +42,6 @@
           <?php
 
     }?>
-        </div><!-- .entry-content -->
+        </div>
 </article><!-- #post-## -->
 <hr>

--- a/partials/content-page.php
+++ b/partials/content-page.php
@@ -13,7 +13,7 @@
 		</header><!-- .entry-header -->
 	</div>
   <div class="row">
-      <div class="entry-content small-24 columns">
+      <div data-swiftype-index='true' class="entry-content small-24 columns">
           <?php the_content(); ?>
           <?php
               //wp_link_pages( array(

--- a/partials/content-single.php
+++ b/partials/content-single.php
@@ -12,7 +12,7 @@
 		</header><!-- .entry-header -->
 	</div>
 	<div class="row">
-        <div class="entry-content small-24 medium-18 columns">
+        <div data-swiftype-index='true' class="entry-content small-24 medium-18 columns">
           <?php the_content(); ?>
                 <?php
                     //wp_link_pages( array(

--- a/single-news_post.php
+++ b/single-news_post.php
@@ -33,13 +33,13 @@ $terms = get_the_terms( $post->ID, 'topics' );
 			<div class="entry-meta small-text">
 				<span class="entry-date"><?php echo get_the_date(); ?> </span>
 				<span class="posted-in">
-					<?php echo  (!$topics == null ? ' | Topics: ' . $topics : ''); ?> 
+					<?php echo  (!$topics == null ? ' | Topics: ' . $topics : ''); ?>
 				</span>
 			</div>
 		</header><!-- .entry-header -->
 	</div>
     <div class="row">
-        <div class="entry-content small-24 medium-18 columns">
+        <div data-swiftype-index='true' class="entry-content small-24 medium-18 columns">
 					<?php
 					if ( has_post_thumbnail() ) { ?>
 	 						<?php	the_post_thumbnail( 'medium', array( 'class' => 'float-left' ) ); ?>

--- a/single-service_post.php
+++ b/single-service_post.php
@@ -14,7 +14,7 @@ get_header(); ?>
 		</header><!-- .entry-header -->
 	</div>
     <div class="row">
-        <div class="entry-content small-24 medium-18 columns">
+        <div data-swiftype-index='true' class="entry-content small-24 medium-18 columns">
             <?php
                 wp_link_pages( array(
                     'before' => '<div class="page-links">' . __( 'Pages:', 'phila-gov' ),

--- a/single-service_post.php
+++ b/single-service_post.php
@@ -27,12 +27,12 @@ get_header(); ?>
                 $service_name = rwmb_meta( 'phila_service_detail', $args = array('type' => 'textrea'));
                 echo '<p class="description">' . rwmb_meta( 'phila_service_desc', $args = array('type' => 'textarea')) . '</p>';
                 if (!$service_url == ''){
-                    echo '<a class="button no-margin" href="';
+                    echo '<a data-swiftype-index="false" class="button no-margin" href="';
                     echo $service_url;
                     echo '">' . 'Start Now' . '<span class="accessible"> external link</span></a>';
                 }
                 if (!$service_name == ''){
-                    echo '<span class="small-text">On the ' . $service_name . ' website</span>';
+                    echo '<span data-swiftype-index="false" class="small-text">On the ' . $service_name . ' website</span>';
                 }
             }
                 the_content();

--- a/templates/single-off-site.php
+++ b/templates/single-off-site.php
@@ -12,6 +12,6 @@
 
     <a class="button icon" href="<?php echo rwmb_meta( 'phila_dept_url', $args = array('type' => 'url')); ?>">You are now leaving
     <?php util_echo_website_url();?> <i class="fa fa-sign-out"></i></a>
-    <?php echo '<p class="description">' . rwmb_meta( 'phila_dept_desc', $args = array('type' => 'textarea')) . '</p>'; ?>
+    <?php echo '<p data-swiftype-name="body" data-swiftype-type="text" class="description">' . rwmb_meta( 'phila_dept_desc', $args = array('type' => 'textarea')) . '</p>'; ?>
   </div><!-- .external-site -->
 </div><!--.entry-content -->

--- a/templates/single-off-site.php
+++ b/templates/single-off-site.php
@@ -6,7 +6,7 @@
 <header class="entry-header small-24 columns">
   <?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
 </header><!-- .entry-header -->
-<div class="entry-content medium-18 small-24 columns end">
+<div data-swiftype-index='true' class="entry-content medium-18 small-24 columns end">
     <div class="external-site">
       <p><?php the_title(); ?> has a <strong>separate website</strong>: <a href="<?php echo rwmb_meta( 'phila_dept_url', $args = array('type' => 'url')); ?>"><?php echo rwmb_meta( 'phila_dept_url', $args = array('type' => 'url')); ?></a></p>
 

--- a/templates/single-on-site.php
+++ b/templates/single-on-site.php
@@ -33,6 +33,6 @@
   <header class="entry-header <?php echo ($has_sidebar) ? 'medium-16' : 'medium-24'; ?> small-24 columns">
     <?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
   </header><!-- .entry-header -->
-  <div class="entry-content <?php echo ($has_sidebar) ? 'medium-16' : 'medium-24'; ?> small-24 columns">
+  <div data-swiftype-index='true' class="entry-content <?php echo ($has_sidebar) ? 'medium-16' : 'medium-24'; ?> small-24 columns">
      <?php echo the_content();?>
   </div>


### PR DESCRIPTION
- Add meta tags and data attributes to help the crawler index better
- Wire up the JS for autocomplete and modal search results
- Allow wp_title to just return the raw page title
